### PR TITLE
Fix: 修复了12章中判断字节序的代码

### DIFF
--- a/Chapter12/bigsmallcheck.cpp
+++ b/Chapter12/bigsmallcheck.cpp
@@ -8,12 +8,8 @@ bool IsSmall() {
     uint32_t data;
   };
   Check check;
-  for (int i = 0; i < 4; i++) {
-    check.bytes[i] = i;
-  }
-  std::cout << "data = " << check.data << std::endl;
-  uint8_t* data = (uint8_t*)&check.data;
-  return data[0] == 0 && data[1] == 1 && data[2] == 2 && data[3] == 3;
+  check.data = 1;
+  return check.bytes[0] == 1;
 }
 
 int main() {

--- a/Chapter12/byteordercheck.cpp
+++ b/Chapter12/byteordercheck.cpp
@@ -3,23 +3,20 @@
 
 #include <iostream>
 
-bool IsSmall(uint32_t value) {
+bool IsSmall() {
   union Check {
     uint8_t bytes[4];
     uint32_t data;
   };
   Check check;
-  check.data = value;
-  std::cout << "data = " << check.data << std::endl;
-  uint8_t* data = (uint8_t*)&check.data;
-  return data[0] == check.bytes[0] && data[1] == check.bytes[1] && data[2] == check.bytes[2] &&
-         data[3] == check.bytes[3];
+  check.data = 1;
+  return check.bytes[0] == 1;
 }
 
 int main() {
   uint32_t hostValue = 666888;
   bool hostValueIsSmall = false;
-  hostValueIsSmall = IsSmall(hostValue);
+  hostValueIsSmall = IsSmall();
   if (hostValueIsSmall) {
     std::cout << "host byte order is small" << std::endl;
   } else {


### PR DESCRIPTION
无论是大端（Big-Endian）系统还是小端（Little-Endian）系统，数组的元素始终都是从低地址向高地址连续排列的，因此无法使用check.bytes来检查字节序。

我通过godbolt在SPARC gcc（大端系统）检查了IsSmall()的汇编，发现原来的IsSmall()实现逻辑无法检测大端。

[点击链接查看godbolt](https://gcc.godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:24,endLineNumber:10,positionColumn:24,positionLineNumber:10,selectionStartColumn:24,selectionStartLineNumber:10,startColumn:24,startLineNumber:10),source:'%23include+%3Cstdint.h%3E%0A%0Abool+IsSmall1()+%7B%0A++union+Check+%7B%0A++++uint8_t+bytes%5B4%5D%3B%0A++++uint32_t+data%3B%0A++%7D%3B%0A++Check+check%3B%0A++for+(int+i+%3D+0%3B+i+%3C+4%3B+i%2B%2B)+%7B%0A++++check.bytes%5Bi%5D+%3D+i%3B%0A++%7D%0A++uint8_t*+data+%3D+(uint8_t*)%26check.data%3B%0A++return+data%5B0%5D+%3D%3D+0+%26%26+data%5B1%5D+%3D%3D+1+%26%26+data%5B2%5D+%3D%3D+2+%26%26+data%5B3%5D+%3D%3D+3%3B%0A%7D%0A%0Abool+IsSmall2()+%7B%0A++union+Check+%7B%0A++++uint8_t+bytes%5B4%5D%3B%0A++++uint32_t+data%3B%0A++%7D%3B%0A++Check+check%3B%0A++check.data+%3D+1%3B%0A++return+check.bytes%5B0%5D+%3D%3D+1%3B%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:sparcg1520,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-O2',overrides:!(),selection:(endColumn:23,endLineNumber:6,positionColumn:23,positionLineNumber:6,selectionStartColumn:23,selectionStartLineNumber:6,startColumn:23,startLineNumber:6),source:1),l:'5',n:'0',o:'+SPARC+gcc+15.2.0+(Editor+%231)',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)